### PR TITLE
Adds package metadata via setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     author='Yordan Miladinov',
     author_email='jordanMiladinov@gmail.com',
     packages=['sameas','sameas.templatetags'],
+    package_data={'sameas':['templates/*/*/*.html']},
     url='https://github.com/ydm/django-sameas',
     license='LICENSE',
     description='Django application that provides you with an easy-to-use template tag that replicates a block.',


### PR DESCRIPTION
I based this on an example at http://guide.python-distribute.org/creation.html with your GitHub project/user info. I went out on a limb and said it requires Django 1.4 based on your claim that it works on 1.5 and likely earlier.

This file seems to be all that's necessary to `pip install` via a repo URL and should make submission to PyPI (#1) much easier for even simpler re-use of this code.
