### PR TITLE
{revent explosion in Django's debug helper due to non-standard encoding

### DIFF
--- a/sameas/templatetags/sameastags.py
+++ b/sameas/templatetags/sameastags.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8-unix -*-
+# -*- coding: utf-8 -*-
 
 #
 # This file is part of Django-SameAs.


### PR DESCRIPTION
When using this helper, any error in templates was met with just a "A server error occurred.  Please contact the administrator." instead of the normal Debug=True error page. The shell logs trace this to:

> …django/views/debug.py", line 406, in _get_lines_from_file
>     source = [six.text_type(sline, encoding, 'replace') for sline in source]
> LookupError: unknown encoding: utf-8-unix

…simplest fix just to drop the `-unix` bit, although I know that's meaningful to Emacs, seems like a poor tradeoff.
