### PR TITLE
Re-render block with current context

### DIFF
--- a/sameas/templatetags/sameastags.py
+++ b/sameas/templatetags/sameastags.py
@@ -62,7 +62,7 @@ class BlockNodeProxy(BlockNode):
 
     def render(self, context):
         result = super(BlockNodeProxy, self).render(context)
-        context[_block_key(self.name)] = self
+        context.setdefault(_block_key(self.name), self)
         return result
 
 

--- a/sameas/templatetags/sameastags.py
+++ b/sameas/templatetags/sameastags.py
@@ -36,7 +36,7 @@ class SameNode(template.Node):
         self.block_name = block_name
 
     def render(self, context):
-        return context[_block_key(self.block_name)]
+        return context[_block_key(self.block_name)].render(context)
 
 
 @register.tag('sameas')
@@ -62,7 +62,7 @@ class BlockNodeProxy(BlockNode):
 
     def render(self, context):
         result = super(BlockNodeProxy, self).render(context)
-        context[_block_key(self.name)] = result
+        context[_block_key(self.name)] = self
         return result
 
 


### PR DESCRIPTION
This PR comes out of necessity. I needed to re-use a `block` but I needed to translate into a different language, hence it needed to be rendered again.

Changes:
* saves `BlockNodeProxy` to context instead of saving the render result
* when rendering `SameNode` it re-renders `BlockNodeProxy` using the current context

I believe this provides greater flexibility to `sameas` since it can reuse a block in dynamic fashion, so to speak.