### PR TITLE
 Add runtests.py and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: python
 python:
   - "3.6"
-  - "3.5"
-  - "3.4"
 env:
   - DJANGO="Django>=2.0,<2.1"
-  - DJANGO="Django>=1.11,<1.12"
-  - DJANGO="Django>=1.10,<1.11"
-  - DJANGO="Django>=1.9,<1.10"
-  - DJANGO="Django>=1.8,<1.9"
+matrix:
+  include:
+  - env: DJANGO="Django>=2.0,<2.1"
+  - env: DJANGO="Django>=1.11,<1.12"
+  - env: DJANGO="Django>=1.10,<1.11"
+  - env: DJANGO="Django>=1.9,<1.10"
+  - env: DJANGO="Django>=1.8,<1.9"
+  - python: "3.5"
+  - python: "3.4"
+  - python: "2.7"
+    env: DJANGO="Django>=1.11,<1.12"
 install:
   - pip install --upgrade -q pip setuptools
   - pip install -q $DJANGO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "3.6"
+  - "3.5"
+  - "3.4"
+env:
+  - DJANGO="Django>=2.0,<2.1"
+  - DJANGO="Django>=1.11,<1.12"
+  - DJANGO="Django>=1.10,<1.11"
+  - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="Django>=1.8,<1.9"
+install:
+  - pip install --upgrade -q pip setuptools
+  - pip install -q $DJANGO
+  - pip install -e .
+script:
+  - ./runtests.py

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.core.management import call_command
+
+
+def runtests():
+    if not settings.configured:
+        # Choose database for settings
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': ':memory:'
+            }
+        }
+
+        # Configure test environment
+        settings.configure(
+            DATABASES=DATABASES,
+            INSTALLED_APPS=(
+                'django.contrib.contenttypes',
+                'django.contrib.auth',
+                'django.contrib.sites',
+                'django.contrib.sessions',
+                'django.contrib.messages',
+                'django.contrib.admin.apps.SimpleAdminConfig',
+                'django.contrib.staticfiles',
+
+                'sameas',
+            ),
+            ROOT_URLCONF='',  # tests override urlconf, but it still needs to be defined
+            MIDDLEWARE_CLASSES=(
+                'django.contrib.sessions.middleware.SessionMiddleware',
+                'django.middleware.common.CommonMiddleware',
+                'django.middleware.csrf.CsrfViewMiddleware',
+                'django.contrib.auth.middleware.AuthenticationMiddleware',
+                'django.contrib.messages.middleware.MessageMiddleware',
+            ),
+            TEMPLATES = [
+                {
+                    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                    'DIRS': [],
+                    'APP_DIRS': True,
+                    'OPTIONS': {
+                        'context_processors': [
+                            'django.template.context_processors.debug',
+                            'django.template.context_processors.request',
+                            'django.contrib.auth.context_processors.auth',
+                            'django.contrib.messages.context_processors.messages',
+                        ],
+                    },
+                },
+            ],
+        )
+
+    if django.VERSION >= (1, 7):
+        django.setup()
+    failures = call_command(
+        'test', 'sameas', interactive=False, failfast=False, verbosity=2)
+
+    sys.exit(bool(failures))
+
+
+if __name__ == '__main__':
+    runtests()
+

--- a/sameas/templatetags/sameastags.py
+++ b/sameas/templatetags/sameastags.py
@@ -62,7 +62,8 @@ class BlockNodeProxy(BlockNode):
 
     def render(self, context):
         result = super(BlockNodeProxy, self).render(context)
-        context.setdefault(_block_key(self.name), self)
+        if _block_key(self.name) not in context:
+            context[_block_key(self.name)] = self
         return result
 
 


### PR DESCRIPTION
Hi @ydm,

This PR adds:

- A script `runtests.py` to run the tests
- A `.travis.yml` config that will produce [these results](https://travis-ci.org/dmarcelino/django-sameas/builds/344346927?utm_source=github_status&utm_medium=notification)
- A fix to `BlockNodeProxy.render()` to make it compatible with Django 1.8

Note: to enable travis builds on this project you'll need to activate it on [settings - Integrations and Services](https://github.com/ydm/django-sameas/settings/installations) and [https://travis-ci.org/profile](https://travis-ci.org/profile).